### PR TITLE
Let http.url tag adhere to the semantic standard

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,14 +35,15 @@ export interface IAxiosOpentracingResponse extends IAxiosResponse {
 function createRequestInterceptor(Tracer: ITracer, rootSpan: ISpan) {
    return function axiosOpentracingRequestInterceptor(config: IAxiosRequestConfig) {
      const modifiedConfig = config as IAxiosOpentracingRequestConfig;
+     const fullURL = `${config.baseURL}${config.url}`;
 
      try {
-       const span = Tracer.startSpan(`${config.method}: ${config.baseURL}${config.url}`, {
+       const span = Tracer.startSpan(`${config.method}: ${fullURL}`, {
          childOf: rootSpan
        });
 
        span.setTag(Tags.HTTP_METHOD, config.method);
-       span.setTag(Tags.HTTP_URL, config.url);
+       span.setTag(Tags.HTTP_URL, fullURL);
        span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_RPC_CLIENT);
        Tracer.inject(span, FORMAT_HTTP_HEADERS, config.headers);
 


### PR DESCRIPTION
I noticed when using this library that the `http.url` tag is always just filled out with the path after the base URL.
According to the Semantic Convention of OpenTracing (and also the newer one from OpenTelemetry) the `http.url` tag has to be filled with the full URI:

> Excerpt below taken from https://github.com/opentracing/specification/blob/master/semantic_conventions.md 
> http.url | string | URL of the request being handled in this segment of the trace, in standard URI format. E.g., "https://domain.net/path/to?resource=here"
> -- | -- | --

This PR changes this behavior by feeding the concatenated full URL to the `http.url` tag.